### PR TITLE
Added National Open University of Nigeria File

### DIFF
--- a/lib/domains/ng/edu/noun.txt
+++ b/lib/domains/ng/edu/noun.txt
@@ -1,0 +1,1 @@
+National Open University of Nigeria


### PR DESCRIPTION
The National Open University of Nigeria is a federal open and distance learning (ODL) institution, the first of its kind in the West African sub-region. It is Nigeria's largest tertiary institution in terms of student numbers, and is popularly referred to as NOUN. https://nou.edu.ng/